### PR TITLE
Add support for well-mixed, blended electrodes that contain more than one active material

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Added support for well-mixed, blended electrodes that contain more than one active material ([#33](https://github.com/pybamm-team/BPX/pull/33))
+
 # [v0.3.0](https://github.com/pybamm-team/BPX/releases/tag/v0.3.0)
 
 - Added a missing factor of 2 in the definition of the interfacial current, see the Butler-Volmer equation (2a) in the associated BPX standard document. The interfacial current is now given by $j=2j_0\sinh(F\eta/2/R/T)$ instead of $j=j_0\sinh(F\eta/2/R/T)$.


### PR DESCRIPTION
Following the implementation idea from the [discussions](https://github.com/pybamm-team/BPX/discussions/22), I basically replaced `negative_electrode: Electrode` with a `Union`:
`negative_electrode: Union[Electrode, Dict[str, Electrode]]`, so that both single and blended electrodes will be supported.

I.e., for non-blended electrodes, nothing changes in the standard:
```
"Negative electrode": {
    "Particle radius [m]": 4.12e-06,
    "Thickness [m]": 5.62e-05,
    ...
}
```

And blended electrodes can be defined as
```
"Negative electrode": {
    "Primary": {
        "Particle radius [m]": 4.12e-06,
        "Thickness [m]": 5.62e-05,
        ...
    },
    "Secondary": {
        "Particle radius [m]": 4.12e-06,
        "Thickness [m]": 5.62e-05,
        ...
    },
    ....
}
```

Related to issue #23.
