### PR TITLE
Add-custom-module-functions-functionality

### DIFF
--- a/bpx/function.py
+++ b/bpx/function.py
@@ -31,6 +31,8 @@ class Function(str):
     def validate(cls, v: str) -> Function:
         if not isinstance(v, str):
             raise TypeError("string required")
+        if '"' in v:
+            return cls(v)
         try:
             cls.parser.parse_string(v)
         except ExpressionParser.ParseException as e:
@@ -56,6 +58,12 @@ class Function(str):
         preamble += "\n\n"
         arg_names = ["x"]
         arg_str = ",".join(arg_names)
+        if '"' in self:
+            nested = True
+        else:
+            nested = False
+        if nested:
+            preamble += f"import {self.split('.')[0]}\n\n"
         function_name = "reconstructed_function"
         function_def = f"def {function_name}({arg_str}):\n"
         function_body = f"  return {self}"
@@ -77,4 +85,7 @@ class Function(str):
 
         # return the new function object
         value = getattr(module, function_name)
-        return value
+        if nested:
+            return value(0)
+        else:
+            return value

--- a/bpx/validators.py
+++ b/bpx/validators.py
@@ -1,5 +1,5 @@
 from warnings import warn
-
+import pybamm
 
 def check_sto_limits(cls, values):
     """
@@ -27,7 +27,13 @@ def check_sto_limits(cls, values):
     tol = cls.settings.tolerances["Voltage [V]"]
 
     # Checks the maximum voltage estimated from STO
-    V_max_sto = ocp_p(sto_p_min) - ocp_n(sto_n_max)
+    negative_ocp = ocp_n(sto_n_max)
+    if isinstance(negative_ocp, pybamm.Scalar):
+        negative_ocp = negative_ocp.evaluate()
+    positive_ocp = ocp_p(sto_p_min)
+    if isinstance(positive_ocp, pybamm.Scalar):
+        positive_ocp = positive_ocp.evaluate()
+    V_max_sto = positive_ocp - negative_ocp
     if V_max_sto - V_max > tol:
         warn(
             f"The maximum voltage computed from the STO limits ({V_max_sto} V) "
@@ -36,7 +42,7 @@ def check_sto_limits(cls, values):
         )
 
     # Checks the minimum voltage estimated from STO
-    V_min_sto = ocp_p(sto_p_max) - ocp_n(sto_n_min)
+    V_min_sto = positive_ocp - negative_ocp
     if V_min_sto - V_min < -tol:
         warn(
             f"The minimum voltage computed from the STO limits ({V_min_sto} V) "


### PR DESCRIPTION
## Motivation:

I would like to be able to specify custom function in my codebase (which returns a pybamm compatible function) in a BPX json file by passing the called function name and any arguments.

## **Example**:

`"OCP [V]": "mypackage.mymodule.myfunction('arg1','arg2')"`

In this case, an import should be added to the preamble, for the package name, and then the function should not be treated as a mathmatical expression.

## TODO:

- Find the right way to recognize that the function is this type of function, and not the mathmatical expression string. Currently, I have looked to see if '"' exists in the string (a string argument will not normally appear in the mathmatical expression version of a BPX function).