### PR TITLE
Support Python 3.9+

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "flit_core.buildapi"
 name = "bpx"
 authors = [{name = "Martin Robinson", email = "martin.robinson@dtc.ox.ac.uk"}]
 readme = "README.md"
+requires-python = ">=3.9"
 dynamic = ["version", "description"]
 dependencies = [
     "devtools",
@@ -15,8 +16,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    'coverage',                 # Coverage checking
-    'flake8>=3',                # Style checking
+    "coverage",                 # Coverage checking
+    "flake8>=3",                # Style checking
     "sphinx>=6",
     "sphinx_rtd_theme>=0.5",
     "pydata-sphinx-theme",


### PR DESCRIPTION
BPX is not supported on Python 3.7 (`Literal` was added to `typing` in Python 3.8) -

https://github.com/FaradayInstitution/BPX/blob/977f1377eacce7ada47a27d5280d32ae28eb4535/bpx/schema.py#L1

Python 3.8 is at EOL, but please let me know if there are plans to keep running BPX on it.