### PR TITLE
Stops incorrect error cascade

### DIFF
--- a/bpx/schema.py
+++ b/bpx/schema.py
@@ -389,8 +389,7 @@ class Parameterisation(ExtraBaseModel):
 
     @model_validator(mode="after")
     def _sto_limit_validation(self) -> Parameterisation:
-        check_sto_limits(self, self.__dict__)
-        return self
+        return check_sto_limits(self)
 
 
 class ParameterisationSPM(ExtraBaseModel):
@@ -423,8 +422,7 @@ class ParameterisationSPM(ExtraBaseModel):
 
     @model_validator(mode="after")
     def _sto_limit_validation(self) -> ParameterisationSPM:
-        check_sto_limits(self, self.__dict__)
-        return self
+        return check_sto_limits(self)
 
 
 class BPX(ExtraBaseModel):

--- a/bpx/schema.py
+++ b/bpx/schema.py
@@ -441,10 +441,9 @@ class BPX(ExtraBaseModel):
     @classmethod
     def _dispatch_param_subclasses(cls, data: Any) -> Any:  # noqa:ANN401
         if isinstance(data, dict):
-            model_type = data.get("Header").get("Model")
-            if model_type is None:
-                error_msg = "Missing 'model' field in Header; cannot choose Parameterisation class"
-                raise ValueError(error_msg)
+            # validate header first, checks that the model type is valid
+            header = Header.model_validate(data.get("Header"))
+            model_type = header.model
 
             if model_type == "SPM":
                 try:
@@ -467,5 +466,7 @@ class BPX(ExtraBaseModel):
                     except ValidationError:
                         raise e from None
 
+            # return validated data to stop double validation
+            data["Header"] = header
             data["Parameterisation"] = parameterisation
         return data

--- a/bpx/validators.py
+++ b/bpx/validators.py
@@ -3,7 +3,7 @@ from warnings import warn
 from .base_extra_model import ExtraBaseModel
 
 
-def check_sto_limits(cls: ExtraBaseModel, values: dict) -> dict:
+def check_sto_limits(param: ExtraBaseModel) -> ExtraBaseModel:
     """
     Validates that the STO limits subbed into the OCPs give the correct voltage limits.
     Works if both OCPs are defined as functions.
@@ -12,21 +12,21 @@ def check_sto_limits(cls: ExtraBaseModel, values: dict) -> dict:
     """
 
     try:
-        ocp_n = values.get("negative_electrode").ocp.to_python_function()
-        ocp_p = values.get("positive_electrode").ocp.to_python_function()
+        ocp_n = param.negative_electrode.ocp.to_python_function()
+        ocp_p = param.positive_electrode.ocp.to_python_function()
     except AttributeError:
         # OCPs defined as interpolated tables or one of the electrodes is blended; do nothing
-        return values
+        return param
 
-    sto_n_min = values.get("negative_electrode").minimum_stoichiometry
-    sto_n_max = values.get("negative_electrode").maximum_stoichiometry
-    sto_p_min = values.get("positive_electrode").minimum_stoichiometry
-    sto_p_max = values.get("positive_electrode").maximum_stoichiometry
-    v_min = values.get("cell").lower_voltage_cutoff
-    v_max = values.get("cell").upper_voltage_cutoff
+    sto_n_min = param.negative_electrode.minimum_stoichiometry
+    sto_n_max = param.negative_electrode.maximum_stoichiometry
+    sto_p_min = param.positive_electrode.minimum_stoichiometry
+    sto_p_max = param.positive_electrode.maximum_stoichiometry
+    v_min = param.cell.lower_voltage_cutoff
+    v_max = param.cell.upper_voltage_cutoff
 
     # Voltage tolerance from `settings` data class
-    tol = cls.Settings.tolerances["Voltage [V]"]
+    tol = param.Settings.tolerances["Voltage [V]"]
 
     # Checks the maximum voltage estimated from STO
     v_max_sto = ocp_p(sto_p_min) - ocp_n(sto_n_max)
@@ -48,5 +48,4 @@ def check_sto_limits(cls: ExtraBaseModel, values: dict) -> dict:
             stacklevel=2,
         )
 
-    return values
-
+    return param

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -214,10 +214,16 @@ class TestSchema(unittest.TestCase):
         test = copy.deepcopy(self.base_spm)
         adapter.validate_python(test)
 
+    def test_missing_model(self) -> None:
+        test = copy.deepcopy(self.base)
+        del test["Header"]["Model"]
+        with pytest.raises(ValidationError, match=re.escape("Model\n  Field required")):
+            adapter.validate_python(test)
+
     def test_bad_model(self) -> None:
         test = copy.deepcopy(self.base)
         test["Header"]["Model"] = "Wrong model type"
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="Input should be 'SPM', 'SPMe' or 'DFN'"):
             adapter.validate_python(test)
 
     def test_bad_dfn(self) -> None:
@@ -311,6 +317,7 @@ class TestSchema(unittest.TestCase):
                 "Temperature [K]": [298.15, 298.15],
             },
         }
+        adapter.validate_python(test)
 
     def test_check_sto_limits_validator(self) -> None:
         warnings.filterwarnings("error")  # Treat warnings as errors


### PR DESCRIPTION
Fixes #52 

Previously, when a BPX file contained a single validation error (e.g. a missing required field), the parser would often return a large number of misleading or redundant errors - sometimes even duplicating the real error. (See the issue #52 for an example.)

This behavior stemmed from how Pydantic handles Union types for fields like `Parameterisation` and negative/positive `Electrode`. Specifically:
* When a model like `ParameterisationSPM` is the first option in a Union, Pydantic tries to parse it first.
* If it fails (e.g. due to missing fields or unexpected extra fields from a different model), it continues trying the next model in the Union.
* Errors from all attempts are retained and reported, including nested errors from submodels like `ElectrodeSingleSPM`, resulting in confusing and noisy output.

For example, if the "Ambient temperature [K]" field is missing from `Cell` for a DFN model:
1. Pydantic first tries `ParameterisationSPM`, raising errors for the missing field and for any extra fields (e.g. DFN-specific fields).
2. It recursively tries to validate nested submodels like `ElectrodeSingleSPM`, which also raise extra field errors.
3. It then tries the correct `Parameterisation` model and raises the real error again.
4. All these errors are returned together, making it hard to pinpoint the actual problem.

While Pydantic offers [discriminated unions](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions) to solve this, doing so requires adding an explicit field for discrimination to the JSON (e.g. `"type": "spm"`) within every class which uses Unions, duplicating information already provided in the Header.

This PR uses a slight workaround with custom model & field validators running before validation, to dynamically dispatch the appropriate class based on the `Header.model` and preventing Pydantic from trying irrelevant Union branches.

As a result, the parser now returns only the relevant error(s), making debugging BPX files much clearer.