### PR TITLE
Use string version for BPX

### DIFF
--- a/bpx/schema.py
+++ b/bpx/schema.py
@@ -23,6 +23,7 @@ class Header(ExtraBaseModel):
         alias="BPX",
         examples=["1.0.0"],
         description="BPX format version",
+        # Update this pattern to make the patch number required once the deprecation warning is removed
         pattern=r"^\d+\.\d+(?:\.\d+)?$",
     )
     title: str = Field(

--- a/examples/lfp_18650_cell_BPX.json
+++ b/examples/lfp_18650_cell_BPX.json
@@ -1,6 +1,6 @@
 {
       "Header": {
-            "BPX": 0.1,
+            "BPX": "0.1.0",
             "Title": "Parameterisation example of an LFP|graphite 2 Ah cylindrical 18650 cell.",
             "Description": "LFP|graphite 2 Ah cylindrical 18650 cell. Parameterisation by About:Energy Limited (aboutenergy.io), December 2022, based on cell cycling data, and electrode data gathered after cell teardown. Electrolyte properties from Nyman et al. 2008 (doi:10.1016/j.electacta.2008.04.023). Negative electrode entropic coefficient data are from O'Regan et al. 2022 (doi:10.1016/j.electacta.2022.140700). Positive electrode entropic coefficient data are from Gerver and Meyers 2011 (doi:10.1149/1.3591799). Other thermal properties are estimated.",
             "Model": "DFN"

--- a/examples/nmc_pouch_cell_BPX.json
+++ b/examples/nmc_pouch_cell_BPX.json
@@ -1,6 +1,6 @@
 {
       "Header": {
-            "BPX": 0.1,
+            "BPX": "0.1.0",
             "Title": "Parameterisation example of an NMC111|graphite 12.5 Ah pouch cell",
             "Description": "NMC111|graphite 12.5 Ah pouch cell. Parameterisation by About:Energy Limited (aboutenergy.io), December 2022, based on cell cycling data, and electrode data gathered after cell teardown. Electrolyte properties from Nyman et al. 2008 (doi:10.1016/j.electacta.2008.04.023). Negative electrode entropic coefficient data are from O'Regan et al. 2022 (doi:10.1016/j.electacta.2022.140700). Positive electrode entropic coefficient data are from Viswanathan et al. 2010 (doi:10.1016/j.jpowsour.2009.11.103). Other thermal properties are estimated.",
             "Model": "DFN"

--- a/examples/nmc_pouch_cell_BPX_SPM.json
+++ b/examples/nmc_pouch_cell_BPX_SPM.json
@@ -1,6 +1,6 @@
 {
       "Header": {
-            "BPX": 0.4,
+            "BPX": "0.4.0",
             "Title": "Test case: Single Particle Model (SPM) parameterisation example based on nmc_pouch_cell_BPX.json from About:Energy open-source release.",
             "Description": "NMC111|graphite 12.5 Ah pouch cell. Parameterisation by About:Energy Limited (aboutenergy.io), December 2022, based on cell cycling data, and electrode data gathered after cell teardown. Negative electrode entropic coefficient data are from O'Regan et al. 2022 (doi:10.1016/j.electacta.2022.140700). Positive electrode entropic coefficient data are from Viswanathan et al. 2010 (doi:10.1016/j.jpowsour.2009.11.103). Other thermal properties are estimated.",
             "Model": "SPM"

--- a/examples/nmc_pouch_cell_BPX_blended_electrode.json
+++ b/examples/nmc_pouch_cell_BPX_blended_electrode.json
@@ -1,6 +1,6 @@
 {
       "Header": {
-            "BPX": 0.4,
+            "BPX": "0.4.0",
             "Title": "Test case: blended electrode definition with two particle sizes but equivalent chemistry. Compare to nmc_pouch_cell_BPX.json in About:Energy open-source release.",
             "Model": "DFN"
       },

--- a/examples/nmc_pouch_cell_BPX_user-defined_hysteresis.json
+++ b/examples/nmc_pouch_cell_BPX_user-defined_hysteresis.json
@@ -1,6 +1,6 @@
 {
       "Header": {
-            "BPX": 0.4,
+            "BPX": "0.4.0",
             "Title": "Test case: user-defined 0th-order hysteresis for graphite-Si blend in negative electrode. Compare to nmc_pouch_cell_BPX.json in About:Energy open-source release.",
             "Model": "DFN"
       },

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -12,7 +12,7 @@ class TestParsers(unittest.TestCase):
         base = """
             {
                 "Header": {
-                        "BPX": 0.1,
+                        "BPX": "0.1.0",
                         "Title": "Parameterisation example of an NMC111|graphite 12.5 Ah pouch cell",
                         "Model": "DFN"
                 },

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -16,7 +16,7 @@ class TestSchema(unittest.TestCase):
     def setUp(self) -> None:
         self.base: dict[str, Any] = {
             "Header": {
-                "BPX": 1.0,
+                "BPX": "1.0.0",
                 "Model": "DFN",
             },
             "Parameterisation": {
@@ -91,7 +91,7 @@ class TestSchema(unittest.TestCase):
         # SPM parameter set
         self.base_spm = {
             "Header": {
-                "BPX": 1.0,
+                "BPX": "1.0.0",
                 "Model": "SPM",
             },
             "Parameterisation": {
@@ -149,7 +149,7 @@ class TestSchema(unittest.TestCase):
         # Non-blended electrodes
         self.base_non_blended = {
             "Header": {
-                "BPX": 1.0,
+                "BPX": "1.0.0",
                 "Model": "SPM",
             },
             "Parameterisation": {
@@ -387,6 +387,18 @@ class TestSchema(unittest.TestCase):
             "bad": True,
         }
         with pytest.raises(TypeError):
+            adapter.validate_python(test)
+
+    def test_deprecated_bpx_version(self) -> None:
+        test = copy.deepcopy(self.base)
+        test["Header"]["BPX"] = 0.4
+        with pytest.warns(DeprecationWarning, match="The 'bpx' field now expects the BPX semantic version as a string"):
+            adapter.validate_python(test)
+
+    def test_bad_bpx_version(self) -> None:
+        test = copy.deepcopy(self.base)
+        test["Header"]["BPX"] = "1.2.3.4"  # Invalid version format
+        with pytest.raises(ValidationError, match="String should match pattern"):
             adapter.validate_python(test)
 
 


### PR DESCRIPTION
Fixes #69 

Converts the `bpx` field to a string, and adds a converter & deprecation warning that the field now expects a semantic version in string format rather than a float. Currently the regex pattern will accept both "0.5" (converted prior to validation from float values) and "0.5.0" (the expected new format).

Once users have had a chance to update their files the deprecation warning should be removed and the regex pattern updated so the patch number is no longer optional.

Example files have been updated to match the new type expectation.