### PR TITLE
Adds a 'State' section with lists of materials

### DIFF
--- a/bpx/schema.py
+++ b/bpx/schema.py
@@ -155,6 +155,24 @@ class Cell(ExtraBaseModel):
             raise ValueError(error_message)
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_temperatures_not_in_cell(cls, data: dict) -> dict:
+        """
+        Validates that initial/ambient temperatures are not provided in the Cell section.
+        If provided, raises an error directing users to the State section.
+        """
+        if isinstance(data, dict) and any(
+            field in data for field in ["Initial temperature [K]", "Ambient temperature [K]"]
+        ):
+            error_message = (
+                "The 'Initial temperature [K]' and 'Ambient temperature [K]' fields have been moved. "
+                "Please provide these parameters in 'State.InitialConditions' and "
+                "'State.ThermalState' sections respectively."
+            )
+            raise ValueError(error_message)
+        return data
+
 
 class Electrolyte(ExtraBaseModel):
     """
@@ -188,6 +206,22 @@ class Electrolyte(ExtraBaseModel):
         examples=[17100],
         description="Activation energy for conductivity in electrolyte",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_initial_concentration(cls, data: dict) -> dict:
+        """
+        Validates that initial concentration is not provided in the Electrolyte section.
+        If provided, raises an error directing users to the State section.
+        """
+        if isinstance(data, dict) and "Initial concentration [mol.m-3]" in data:
+            error_message = (
+                "'Initial concentration [mol.m-3]' has been renamed and moved. "
+                "Please provide this parameter as 'Initial electrolyte concentration [mol.m-3]'"
+                " in the 'State.InitialConditions' section instead."
+            )
+            raise ValueError(error_message)
+        return data
 
 
 class ContactBase(ExtraBaseModel):

--- a/bpx/schema.py
+++ b/bpx/schema.py
@@ -503,13 +503,13 @@ class InitialConditions(ExtraBaseModel):
 
     initial_hysteresis_state_positive: FloatInt | dict[str, FloatInt] = Field(
         alias="Initial hysteresis state: Positive electrode",
-        examples=[0.0],
+        examples=[1.0, {"Primary": 1.0, "Secondary": 5.0}],
         description=("Initial hysteresis state for positive electrode"),
     )
 
     initial_hysteresis_state_negative: FloatInt | dict[str, FloatInt] = Field(
         alias="Initial hysteresis state: Negative electrode",
-        examples=[0.0],
+        examples=[1.0, {"Primary": 1.0, "Secondary": 5.0}],
         description=("Initial hysteresis state for negative electrode"),
     )
 
@@ -518,6 +518,11 @@ class ThermalState(ExtraBaseModel):
     ambient_temperature: FloatInt = Field(
         alias="Ambient temperature [K]",
         examples=[298.15],
+    )
+
+    heat_transfer_coefficient: FloatInt = Field(
+        alias="Heat transfer coefficient [W.m-2.K-1]",
+        examples=[10.0],
     )
 
 

--- a/bpx/schema.py
+++ b/bpx/schema.py
@@ -117,19 +117,8 @@ class Cell(ExtraBaseModel):
     )
     nominal_cell_capacity: FloatInt = Field(
         alias="Nominal cell capacity [A.h]",
-        description=(
-            "Nominal cell capacity. Used to convert between current and C-rate."
-        ),
+        description=("Nominal cell capacity. Used to convert between current and C-rate."),
         examples=[5.0],
-    )
-    ambient_temperature: FloatInt = Field(
-        alias="Ambient temperature [K]",
-        examples=[298.15],
-    )
-    initial_temperature: FloatInt = Field(
-        None,
-        alias="Initial temperature [K]",
-        examples=[298.15],
     )
     reference_temperature: FloatInt = Field(
         None,
@@ -171,11 +160,6 @@ class Electrolyte(ExtraBaseModel):
     Electrolyte parameters.
     """
 
-    initial_concentration: FloatInt = Field(
-        alias="Initial concentration [mol.m-3]",
-        examples=[1000],
-        description=("Initial / rest lithium ion concentration in the electrolyte"),
-    )
     cation_transference_number: FloatInt = Field(
         alias="Cation transference number",
         examples=[0.259],
@@ -184,9 +168,7 @@ class Electrolyte(ExtraBaseModel):
     diffusivity: FloatFunctionTable = Field(
         alias="Diffusivity [m2.s-1]",
         examples=["8.794e-7 * x * x - 3.972e-6 * x + 4.862e-6"],
-        description=(
-            "Lithium ion diffusivity in electrolyte (constant or function of concentration)"
-        ),
+        description=("Lithium ion diffusivity in electrolyte (constant or function of concentration)"),
     )
     diffusivity_activation_energy: FloatInt = Field(
         None,
@@ -197,9 +179,7 @@ class Electrolyte(ExtraBaseModel):
     conductivity: FloatFunctionTable = Field(
         alias="Conductivity [S.m-1]",
         examples=[1.0],
-        description=(
-            "Electrolyte conductivity (constant or function of concentration)"
-        ),
+        description=("Electrolyte conductivity (constant or function of concentration)"),
     )
     conductivity_activation_energy: FloatInt = Field(
         None,
@@ -271,9 +251,7 @@ class Particle(ExtraBaseModel):
     diffusivity: FloatFunctionTable = Field(
         alias="Diffusivity [m2.s-1]",
         examples=["3.3e-14"],
-        description=(
-            "Lithium ion diffusivity in particle (constant or function of stoichiometry)"
-        ),
+        description=("Lithium ion diffusivity in particle (constant or function of stoichiometry)"),
     )
     diffusivity_activation_energy: FloatInt = Field(
         None,
@@ -284,9 +262,7 @@ class Particle(ExtraBaseModel):
     ocp: FloatFunctionTable = Field(
         alias="OCP [V]",
         examples=[{"x": [0, 0.1, 1], "y": [1.72, 1.2, 0.06]}],
-        description=(
-            "Open-circuit potential (OCP) at the reference temperature, function of particle stoichiometry"
-        ),
+        description=("Open-circuit potential (OCP) at the reference temperature, function of particle stoichiometry"),
     )
     ocp_delith: FloatFunctionTable = Field(
         None,
@@ -339,9 +315,7 @@ class Electrode(Contact):
     conductivity: FloatInt = Field(
         alias="Conductivity [S.m-1]",
         examples=[0.18],
-        description=(
-            "Effective electronic conductivity of the porous electrode matrix (constant)"
-        ),
+        description=("Effective electronic conductivity of the porous electrode matrix (constant)"),
     )
 
 
@@ -509,6 +483,72 @@ class ParameterisationSPM(ExtraBaseModel):
         return check_sto_limits(self)
 
 
+class InitialConditions(ExtraBaseModel):
+    initial_soc: FloatInt = Field(
+        alias="Initial state-of-charge",
+        examples=[0.5],
+        description=("Initial state of charge of the battery (between 0 and 1)"),
+    )
+
+    initial_temperature: FloatInt = Field(
+        alias="Initial temperature [K]",
+        examples=[298.15],
+    )
+
+    initial_electrolyte_concentration: FloatInt = Field(
+        alias="Initial electrolyte concentration [mol.m-3]",
+        examples=[1000],
+        description=("Initial / rest lithium ion concentration in the electrolyte"),
+    )
+
+    initial_hysteresis_state_positive: FloatInt | dict[str, FloatInt] = Field(
+        alias="Initial hysteresis state: Positive electrode",
+        examples=[0.0],
+        description=("Initial hysteresis state for positive electrode"),
+    )
+
+    initial_hysteresis_state_negative: FloatInt | dict[str, FloatInt] = Field(
+        alias="Initial hysteresis state: Negative electrode",
+        examples=[0.0],
+        description=("Initial hysteresis state for negative electrode"),
+    )
+
+
+class ThermalState(ExtraBaseModel):
+    ambient_temperature: FloatInt = Field(
+        alias="Ambient temperature [K]",
+        examples=[298.15],
+    )
+
+
+class Degradation(ExtraBaseModel):
+    lli: FloatInt = Field(
+        alias="LLI",
+    )
+
+    lam_positive: FloatInt | dict[str, FloatInt] = Field(
+        alias="LAM: Positive electrode",
+    )
+    lam_negative: FloatInt | dict[str, FloatInt] = Field(
+        alias="LAM: Negative electrode",
+    )
+
+
+class State(ExtraBaseModel):
+    initial_conditions: InitialConditions = Field(
+        alias="Initial conditions",
+    )
+
+    thermal_state: ThermalState = Field(
+        alias="Thermal state",
+    )
+
+    degradation: Degradation = Field(
+        None,
+        alias="Degradation",
+    )
+
+
 class BPX(ExtraBaseModel):
     """
     A class to store a BPX model. Consists of a header, parameterisation, and optional
@@ -521,6 +561,7 @@ class BPX(ExtraBaseModel):
     parameterisation: Union[ParameterisationSPM, Parameterisation] = Field(
         alias="Parameterisation",
     )
+    state: State = Field(alias="State")
     validation: dict[str, Experiment] = Field(None, alias="Validation")
 
     @model_validator(mode="before")

--- a/bpx/schema.py
+++ b/bpx/schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import Any, Literal, Union
 
 from pydantic import (
     BaseModel,
@@ -15,10 +15,8 @@ from pydantic import (
 from bpx import Function, InterpolatedTable
 
 from .base_extra_model import ExtraBaseModel
+from .schema_utils import get_materials_in_electrode, validate_section_against_electrodes
 from .validators import check_sto_limits
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
 
 FloatFunctionTable = Union[float, int, Function, InterpolatedTable]
 FloatInt = Union[float, int]
@@ -540,6 +538,7 @@ class Degradation(ExtraBaseModel):
         alias="LAM: Positive electrode",
         json_schema_extra={"material_check": "positive_electrode"},
     )
+
     lam_negative: FloatInt | dict[str, FloatInt] = Field(
         alias="LAM: Negative electrode",
         json_schema_extra={"material_check": "negative_electrode"},
@@ -613,68 +612,23 @@ class BPX(ExtraBaseModel):
         values in State are provided as such (and vice versa).
         """
 
-        def _materials_in_electrode(e: dict) -> set[str] | None:
-            part = getattr(e, "particle", None)
-            if isinstance(part, dict) and part:
-                return set(part.keys())
-            return None
-
-        def _find_tagged_fields(model: ExtraBaseModel) -> Iterable[tuple[str, Any, str]]:
-            for name, f in model.__class__.model_fields.items():
-                tag = None
-                jsx = f.json_schema_extra
-                if jsx:
-                    tag = jsx.get("material_check")
-                if tag:
-                    yield f.alias, getattr(model, name), str(tag)
-
-        def _validate_value_against_keys(
-            value: FloatInt | dict[str, FloatInt],
-            expected_keys: set[str] | None,
-            field_path: str,
-        ) -> None:
-            """
-            expected_keys is None for single-material electrodes (value must be scalar),
-            or a set[str] for blended electrodes (value must be dict with exact same keys of scalars).
-            """
-            if expected_keys is None:
-                # single-material: require scalar
-                if isinstance(value, dict):
-                    msg = f"{field_path!r} must be a float. Electrode is a single material."
-                    raise ValueError(msg)
-                return
-
-            # blended: require dict with same keys
-            if not isinstance(value, dict):
-                msg = f"{field_path!r} must be a dict with keys {sorted(expected_keys)}. Electrode is blended."
-                raise ValueError(msg)  # noqa: TRY004
-
-            value_keys = set(value.keys())
-            if value_keys != expected_keys:
-                missing = sorted(expected_keys - value_keys)
-                extra = sorted(value_keys - expected_keys)
-                parts = []
-                if missing:
-                    parts.append(f"missing keys: {missing}")
-                if extra:
-                    parts.append(f"unexpected keys: {extra}")
-                raise ValueError(f"{field_path!r} keys must exactly match {sorted(expected_keys)}; " + ", ".join(parts))
-
         param = self.parameterisation
 
         electrode_materials = {
-            "negative_electrode": _materials_in_electrode(param.negative_electrode),
-            "positive_electrode": _materials_in_electrode(param.positive_electrode),
+            "negative_electrode": get_materials_in_electrode(param.negative_electrode),
+            "positive_electrode": get_materials_in_electrode(param.positive_electrode),
         }
 
-        # Validate all tagged fields in State submodels
-        def validate_section(section_model: BaseModel, section_label: str) -> None:
-            for attr, value, tag in _find_tagged_fields(section_model):
-                # tag should be 'negative_electrode' or 'positive_electrode'
-                _validate_value_against_keys(value, electrode_materials[tag], f"State.{section_label}.{attr}")
-
-        validate_section(self.state.initial_conditions, "Initial conditions")
+        validate_section_against_electrodes(
+            self.state.initial_conditions,
+            "Initial conditions",
+            electrode_materials,
+        )
         if self.state.degradation is not None:
-            validate_section(self.state.degradation, "Degradation")
+            validate_section_against_electrodes(
+                self.state.degradation,
+                "Degradation",
+                electrode_materials,
+            )
 
         return self

--- a/bpx/schema_utils.py
+++ b/bpx/schema_utils.py
@@ -1,0 +1,97 @@
+from collections.abc import Iterable
+from typing import Any, Union
+
+from .base_extra_model import ExtraBaseModel
+
+FloatInt = Union[float, int]
+
+
+class BPXSchemaError(ValueError):
+    """Custom exception for schema validation errors."""
+
+
+def get_materials_in_electrode(e: dict) -> set[str] | None:
+    """
+    Returns a set of material keys from 'particle' in an electrode dict, or None if
+    electrode is a single-material.
+    """
+    part = getattr(e, "particle", None)
+    if isinstance(part, dict) and part:
+        return set(part.keys())
+    return None
+
+
+def _find_tagged_fields(model: ExtraBaseModel) -> Iterable[tuple[str, Any, str]]:
+    """
+    Yields (alias, value, tag) for fields in a single class tagged with 'material_check'
+    in `json_schema_extra`.
+    """
+    for name, f in model.__class__.model_fields.items():
+        tag = None
+        jsx = f.json_schema_extra
+        if jsx:
+            tag = jsx.get("material_check")
+        if tag:
+            yield f.alias, getattr(model, name), str(tag)
+
+
+def _validate_value_against_keys(
+    value: FloatInt | dict[str, FloatInt],
+    expected_keys: set[str] | None,
+    field_path: str,
+) -> None:
+    """
+    Checks the contents of a single field against the expected material keys from the
+    electrode parameterisation.
+
+    `expected_keys` is None for single-material electrodes (`value` must be scalar),
+    or a set[str] for blended electrodes (`value` must be dict with `expected_keys`).
+    """
+    if expected_keys is None:
+        # single-material: require scalar
+        if isinstance(value, dict):
+            msg = f"{field_path!r} must be a float. Electrode is a single material."
+            raise BPXSchemaError(msg)
+        return
+
+    # blended: require dict with same keys
+    if not isinstance(value, dict):
+        msg = f"{field_path!r} must be a dict with keys {sorted(expected_keys)}. Electrode is blended."
+        raise BPXSchemaError(msg)
+
+    value_keys = set(value.keys())
+    if value_keys != expected_keys:
+        missing = sorted(expected_keys - value_keys)
+        extra = sorted(value_keys - expected_keys)
+        parts = []
+        if missing:
+            parts.append(f"missing keys: {missing}")
+        if extra:
+            parts.append(f"unexpected keys: {extra}")
+        raise BPXSchemaError(f"{field_path!r} keys must exactly match {sorted(expected_keys)}; " + ", ".join(parts))
+
+
+def validate_section_against_electrodes(
+    section_model: ExtraBaseModel,
+    section_label: str,
+    electrode_materials: dict[str, set[str] | None],
+) -> None:
+    """
+    Validates all fields in a pydantic class against the appropriate electrode materials.
+
+    Assumes that fields which need to be checked are tagged with 'material_check' in their
+    json_schema_extra metadata, with value 'negative_electrode' or 'positive_electrode'.
+
+    E.g. for a single field:
+
+    lam_positive: FloatInt | dict[str, FloatInt] = Field(
+        alias="LAM: Positive electrode",
+        json_schema_extra={"material_check": "positive_electrode"},
+    )
+    """
+    for alias, value, tag in _find_tagged_fields(section_model):
+        _validate_value_against_keys(
+            value,
+            electrode_materials.get(tag),
+            f"State.{section_label}.{alias}",
+        )

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -18,8 +18,6 @@ class TestParsers(unittest.TestCase):
                 },
                 "Parameterisation": {
                         "Cell": {
-                            "Ambient temperature [K]": 298.15,
-                            "Initial temperature [K]": 298.15,
                             "Reference temperature [K]": 298.15,
                             "Lower voltage cut-off [V]": 2.7,
                             "Upper voltage cut-off [V]": 4.2,
@@ -32,7 +30,6 @@ class TestParsers(unittest.TestCase):
                             "Volume [m3]": 0.000128
                         },
                         "Electrolyte": {
-                            "Initial concentration [mol.m-3]": 1000,
                             "Cation transference number": 0.2594,
                             "Conductivity [S.m-1]":
                                 "0.1297 * (x / 1000) ** 3 - 2.51 * (x / 1000) ** 1.5 + 3.329 * (x / 1000)",
@@ -88,9 +85,21 @@ class TestParsers(unittest.TestCase):
                             "Thickness [m]": 2e-05,
                             "Porosity": 0.47,
                             "Transport efficiency": 0.3222
+                            }
+                        },
+                        "State": {
+                            "Initial conditions": {
+                                "Initial state-of-charge": 100,
+                                "Initial electrolyte concentration [mol.m-3]": 1000,
+                                "Initial temperature [K]": 299,
+                                "Initial hysteresis state: Negative electrode": 5,
+                                "Initial hysteresis state: Positive electrode": 10
+                            },
+                            "Thermal state": {
+                                "Ambient temperature [K]": 299
+                                }
+                            }
                         }
-                }
-            }
             """
         self.base = base.replace("\n", "")
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -96,7 +96,8 @@ class TestParsers(unittest.TestCase):
                                 "Initial hysteresis state: Positive electrode": 10
                             },
                             "Thermal state": {
-                                "Ambient temperature [K]": 299
+                                "Ambient temperature [K]": 299,
+                                "Heat transfer coefficient [W.m-2.K-1]": 10.0
                                 }
                             }
                         }

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import unittest
 import warnings
 
@@ -156,5 +157,35 @@ class TestParsers(unittest.TestCase):
         with pytest.raises(
             ValueError,
             match="The 'Thermal conductivity \\[W\\.m-1\\.K-1\\]' field is not part of the BPX schema",
+        ):
+            parse_bpx_str(test)
+
+    def test_temps_in_cell_error(self) -> None:
+        """Test that providing initial temperature in Cell section raises an error."""
+        test = copy.copy(self.base)
+        # Add initial temperature to the Cell section
+        test = test.replace(
+            '"Reference temperature [K]": 298.15,',
+            '"Reference temperature [K]": 298.15, "Initial temperature [K]": 299,',
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("The 'Initial temperature [K]' and 'Ambient temperature [K]' fields have been moved."),
+        ):
+            parse_bpx_str(test)
+
+    def test_initial_concentration_error(self) -> None:
+        """Test that providing initial concentration in Electrolyte section raises an error."""
+        test = copy.copy(self.base)
+        # Add initial concentration to the Electrolyte section
+        test = test.replace(
+            '"Cation transference number": 0.2594,',
+            '"Cation transference number": 0.2594, "Initial concentration [mol.m-3]": 1000,',
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("'Initial concentration [mol.m-3]' has been renamed and moved."),
         ):
             parse_bpx_str(test)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -21,8 +21,6 @@ class TestSchema(unittest.TestCase):
             },
             "Parameterisation": {
                 "Cell": {
-                    "Ambient temperature [K]": 299.0,
-                    "Initial temperature [K]": 299.0,
                     "Reference temperature [K]": 299.0,
                     "Electrode area [m2]": 2.0,
                     "External surface area [m2]": 2.2,
@@ -33,7 +31,6 @@ class TestSchema(unittest.TestCase):
                     "Upper voltage cut-off [V]": 4.0,
                 },
                 "Electrolyte": {
-                    "Initial concentration [mol.m-3]": 1000,
                     "Cation transference number": 0.259,
                     "Conductivity [S.m-1]": 1.0,
                     "Diffusivity [m2.s-1]": ("8.794e-7 * x * x - 3.972e-6 * x + 4.862e-6"),
@@ -86,6 +83,21 @@ class TestSchema(unittest.TestCase):
                     "Transport efficiency": 0.3222,
                 },
             },
+            "State": {
+                "Initial conditions": {
+                    "Initial state-of-charge": 100,
+                    "Initial electrolyte concentration [mol.m-3]": 1000,
+                    "Initial temperature [K]": 299,
+                    "Initial hysteresis state: Negative electrode": 5,
+                    "Initial hysteresis state: Positive electrode": {
+                        "Primary": 10,
+                        "Secondary": 10,
+                    },
+                },
+                "Thermal state": {
+                    "Ambient temperature [K]": 299,
+                },
+            },
         }
 
         # SPM parameter set
@@ -96,8 +108,6 @@ class TestSchema(unittest.TestCase):
             },
             "Parameterisation": {
                 "Cell": {
-                    "Ambient temperature [K]": 299.0,
-                    "Initial temperature [K]": 299.0,
                     "Reference temperature [K]": 299.0,
                     "Electrode area [m2]": 2,
                     "External surface area [m2]": 2.2,
@@ -144,6 +154,21 @@ class TestSchema(unittest.TestCase):
                     },
                 },
             },
+            "State": {
+                "Initial conditions": {
+                    "Initial state-of-charge": 100,
+                    "Initial electrolyte concentration [mol.m-3]": 1000,
+                    "Initial temperature [K]": 299,
+                    "Initial hysteresis state: Positive electrode": {
+                        "Primary": 10,
+                        "Secondary": 10,
+                    },
+                    "Initial hysteresis state: Negative electrode": 5,
+                },
+                "Thermal state": {
+                    "Ambient temperature [K]": 299,
+                },
+            },
         }
 
         # Non-blended electrodes
@@ -154,8 +179,6 @@ class TestSchema(unittest.TestCase):
             },
             "Parameterisation": {
                 "Cell": {
-                    "Ambient temperature [K]": 299.0,
-                    "Initial temperature [K]": 299.0,
                     "Reference temperature [K]": 299.0,
                     "Electrode area [m2]": 2.0,
                     "External surface area [m2]": 2.2,
@@ -197,6 +220,18 @@ class TestSchema(unittest.TestCase):
                     "Maximum concentration [mol.m-3]": 63104.0,
                     "Minimum stoichiometry": 0.42424,
                     "Maximum stoichiometry": 0.96210,
+                },
+            },
+            "State": {
+                "Initial conditions": {
+                    "Initial state-of-charge": 100,
+                    "Initial electrolyte concentration [mol.m-3]": 1000,
+                    "Initial temperature [K]": 299,
+                    "Initial hysteresis state: Positive electrode": 10,
+                    "Initial hysteresis state: Negative electrode": 5,
+                },
+                "Thermal state": {
+                    "Ambient temperature [K]": 299,
                 },
             },
         }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -96,6 +96,7 @@ class TestSchema(unittest.TestCase):
                 },
                 "Thermal state": {
                     "Ambient temperature [K]": 299,
+                    "Heat transfer coefficient [W.m-2.K-1]": 10.0,
                 },
             },
         }
@@ -167,6 +168,7 @@ class TestSchema(unittest.TestCase):
                 },
                 "Thermal state": {
                     "Ambient temperature [K]": 299,
+                    "Heat transfer coefficient [W.m-2.K-1]": 10.0,
                 },
             },
         }
@@ -232,6 +234,7 @@ class TestSchema(unittest.TestCase):
                 },
                 "Thermal state": {
                     "Ambient temperature [K]": 299,
+                    "Heat transfer coefficient [W.m-2.K-1]": 10.0,
                 },
             },
         }

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -76,6 +76,7 @@ class TestUtlilities(unittest.TestCase):
                 },
                 "Thermal state": {
                     "Ambient temperature [K]": 299,
+                    "Heat transfer coefficient [W.m-2.K-1]": 10.0,
                 },
             },
         }

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -18,8 +18,6 @@ class TestUtlilities(unittest.TestCase):
             },
             "Parameterisation": {
                 "Cell": {
-                    "Ambient temperature [K]": 299.0,
-                    "Initial temperature [K]": 299.0,
                     "Reference temperature [K]": 299.0,
                     "Electrode area [m2]": 2.0,
                     "External surface area [m2]": 2.2,
@@ -30,7 +28,6 @@ class TestUtlilities(unittest.TestCase):
                     "Upper voltage cut-off [V]": 4.0,
                 },
                 "Electrolyte": {
-                    "Initial concentration [mol.m-3]": 1000,
                     "Cation transference number": 0.259,
                     "Conductivity [S.m-1]": 1.0,
                     "Diffusivity [m2.s-1]": ("8.794e-7 * x * x - 3.972e-6 * x + 4.862e-6"),
@@ -67,6 +64,18 @@ class TestUtlilities(unittest.TestCase):
                     "Thickness [m]": 1.2e-5,
                     "Porosity": 0.47,
                     "Transport efficiency": 0.3222,
+                },
+            },
+            "State": {
+                "Initial conditions": {
+                    "Initial state-of-charge": 100,
+                    "Initial electrolyte concentration [mol.m-3]": 1000,
+                    "Initial temperature [K]": 299,
+                    "Initial hysteresis state: Negative electrode": 5,
+                    "Initial hysteresis state: Positive electrode": 10,
+                },
+                "Thermal state": {
+                    "Ambient temperature [K]": 299,
                 },
             },
         }


### PR DESCRIPTION
Fixes #4 
Fixes #89

Adds a 'State' section to the schema as per BPX 1.0. All `Initial conditions` & `Thermal state` params are required, while `Degradation` is optional.

Parameters described in the current BPX schema as 'colon separated' are implemented as follows:
```
Degradation: {
  "LLI": 5
  "LAM: Positive electrode": {
     "Primary": 10,
     "Secondary": 20
     }
  "LAM: Negative electrode": 15
}
```
following discussions in #112.

Errors are raised directing users to the new `State` section where existing parameters have been moved.

I haven't made any currently optional parameters required (see https://github.com/FaradayInstitution/BPX/issues/89#issuecomment-2648467934) as I'm not entirely clear which should be changed.