### PR TITLE
feat: make all State variables optional (#126, #127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased](https://github.com/FaradayInstitution/BPX)
 
+- All `State` variables are now optional, leaving simulators to default any value that is not provided. This makes the initial electrolyte concentration optional (e.g. for SPM, which has no `Electrolyte` section, [#127](https://github.com/FaradayInstitution/BPX/issues/127)) and the initial hysteresis state optional (e.g. for materials with no hysteresis OCP branch, [#126](https://github.com/FaradayInstitution/BPX/issues/126)). A non-`Partial` file may now also omit the `State` section entirely. The legacy v0.x converter no longer synthesises placeholder values for these optional fields.
+
 # [v1.1.1](https://github.com/FaradayInstitution/BPX/releases/tag/v1.1.1)
 
 - Added backward-compatible loading of legacy BPX v0.x files: `parse_bpx_file`, `parse_bpx_obj` and `parse_bpx_str` now detect a v0.x object and convert it to the v1.x schema on a best-effort basis, raising a `UserWarning`. Conversion can be disabled with `convert_legacy=False`. The converter is also exposed directly as `bpx.convert_v0_to_v1` / `bpx.is_legacy_bpx`.

--- a/bpx/_migrations.py
+++ b/bpx/_migrations.py
@@ -16,9 +16,6 @@ from __future__ import annotations
 import copy
 import re
 
-# Electrode prefixes for the synthesised hysteresis state.
-_ELECTRODES = ("Negative", "Positive")
-
 
 def _first_not_none(*values: float | None, default: float) -> float:
     """Return the first value that is not ``None``, or ``default`` if all are."""
@@ -68,14 +65,15 @@ def convert_v0_to_v1(bpx_obj: dict) -> dict:
     (the input is not mutated).
 
     The v1.x ``State`` block is synthesised from the v0.x ``Parameterisation``
-    entries, with placeholders for the required fields v0.x lacks: initial SOC
-    set to ``1``, heat transfer coefficient and initial hysteresis state set to
-    ``0`` (the lumped ``Thermal conductivity`` has no v1.x equivalent and is
-    dropped), the ambient and initial temperatures resolved from whichever of
-    ambient/initial/reference temperature the file provides (defaulting to
-    ``298.15`` K only if none are present), and initial electrolyte concentration
-    falling back to ``1000`` mol.m-3 (1 M) when absent (e.g. SPM files that have
-    no ``Electrolyte`` section). Cross-version semantic changes are not adjusted.
+    entries: initial SOC is set to ``1``; the ambient and initial temperatures are
+    resolved from whichever of ambient/initial/reference temperature the file
+    provides (defaulting to ``298.15`` K only if none are present); and the initial
+    electrolyte concentration is carried across when present (the lumped
+    ``Thermal conductivity`` has no v1.x equivalent and is dropped). Fields that are
+    optional in v1.x and have no v0.x equivalent (initial hysteresis state, heat
+    transfer coefficient, and the electrolyte concentration for SPM files with no
+    ``Electrolyte`` section) are omitted rather than synthesised, leaving simulators
+    to apply their own defaults. Cross-version semantic changes are not adjusted.
     """
     params = copy.deepcopy(bpx_obj)
     parameterisation = params.get("Parameterisation", {})
@@ -102,27 +100,22 @@ def convert_v0_to_v1(bpx_obj: dict) -> dict:
         "Initial temperature [K]": initial_temperature,
     }
 
-    # Required in v1.x; fall back to 1 M when absent (e.g. SPM files with no
-    # Electrolyte section). See https://github.com/FaradayInstitution/BPX/issues/127.
+    # Optional in v1.x, but renamed and moved out of Electrolyte, so carry across
+    # any value the v0.x file provides. SPM files have no Electrolyte section and
+    # the field is simply omitted (simulators supply their own default).
+    # See https://github.com/FaradayInstitution/BPX/issues/127.
     initial_electrolyte_concentration = electrolyte.pop(
         "Initial concentration [mol.m-3]",
         None,
     )
-    initial_conditions["Initial electrolyte concentration [mol.m-3]"] = (
-        initial_electrolyte_concentration if initial_electrolyte_concentration is not None else 1000
-    )
+    if initial_electrolyte_concentration is not None:
+        initial_conditions["Initial electrolyte concentration [mol.m-3]"] = initial_electrolyte_concentration
 
-    # Placeholder hysteresis state; blended electrodes need a per-phase dict.
-    for electrode in _ELECTRODES:
-        electrode_params = parameterisation.get(f"{electrode} electrode", {})
-        key = f"Initial hysteresis state: {electrode} electrode"
-        if "Particle" in electrode_params:
-            initial_conditions[key] = dict.fromkeys(electrode_params["Particle"], 0)
-        else:
-            initial_conditions[key] = 0
-
+    # Initial hysteresis state and heat transfer coefficient are optional in v1.x
+    # and have no v0.x equivalent, so they are left for the simulator to default
+    # rather than synthesised here. See
+    # https://github.com/FaradayInstitution/BPX/issues/126.
     thermal_environment: dict = {
-        "Heat transfer coefficient [W.m-2.K-1]": 0,
         "Ambient temperature [K]": ambient_temperature,
     }
 

--- a/bpx/parsers.py
+++ b/bpx/parsers.py
@@ -11,12 +11,12 @@ from .schema import BPX
 
 _LEGACY_CONVERSION_WARNING = (
     "Detected a legacy BPX v0.x file/object; converting to the v1.x schema for "
-    "backward compatibility. The conversion is approximate: the required 'State' "
-    "fields are synthesised with placeholders (heat transfer coefficient and "
-    "initial hysteresis state set to 0, initial electrolyte concentration "
-    "defaulted to 1000 mol.m-3 when absent, lumped thermal conductivity dropped) "
-    "and cross-version semantic changes are not corrected. Re-export from bpx>=1 "
-    "to silence this warning, or pass convert_legacy=False to disable conversion."
+    "backward compatibility. The conversion is approximate: the 'State' block is "
+    "synthesised from the v0.x parameterisation (initial SOC set to 1, ambient and "
+    "initial temperatures resolved from those provided, lumped thermal conductivity "
+    "dropped), optional fields with no v0.x equivalent are left for the simulator to "
+    "default, and cross-version semantic changes are not corrected. Re-export from "
+    "bpx>=1 to silence this warning, or pass convert_legacy=False to disable conversion."
 )
 
 

--- a/bpx/schema.py
+++ b/bpx/schema.py
@@ -15,7 +15,7 @@ from pydantic import (
 from bpx import Function, InterpolatedTable
 
 from .base_extra_model import ExtraBaseModel
-from .schema_utils import BPXSchemaError, get_materials_in_electrode, validate_section_against_electrodes
+from .schema_utils import get_materials_in_electrode, validate_section_against_electrodes
 from .validators import check_sto_limits
 
 FloatFunctionTable = Union[float, int, Function, InterpolatedTable]
@@ -622,31 +622,36 @@ class ParameterisationSPM(ExtraBaseModel):
 
 
 class InitialConditions(ExtraBaseModel):
-    initial_soc: FloatInt = Field(
+    initial_soc: FloatInt | None = Field(
+        None,
         alias="Initial state-of-charge",
         examples=[0.5],
         description=("Initial state of charge of the battery (between 0 and 1)"),
     )
 
-    initial_temperature: FloatInt = Field(
+    initial_temperature: FloatInt | None = Field(
+        None,
         alias="Initial temperature [K]",
         examples=[298.15],
     )
 
-    initial_electrolyte_concentration: FloatInt = Field(
+    initial_electrolyte_concentration: FloatInt | None = Field(
+        None,
         alias="Initial electrolyte concentration [mol.m-3]",
         examples=[1000],
         description=("Initial / rest lithium ion concentration in the electrolyte"),
     )
 
-    initial_hysteresis_state_positive: FloatInt | dict[str, FloatInt] = Field(
+    initial_hysteresis_state_positive: FloatInt | dict[str, FloatInt] | None = Field(
+        None,
         alias="Initial hysteresis state: Positive electrode",
         examples=[1.0, {"Primary": 1.0, "Secondary": 5.0}],
         description=("Initial hysteresis state for positive electrode"),
         json_schema_extra={"material_check": "positive_electrode"},
     )
 
-    initial_hysteresis_state_negative: FloatInt | dict[str, FloatInt] = Field(
+    initial_hysteresis_state_negative: FloatInt | dict[str, FloatInt] | None = Field(
+        None,
         alias="Initial hysteresis state: Negative electrode",
         examples=[1.0, {"Primary": 1.0, "Secondary": 5.0}],
         description=("Initial hysteresis state for negative electrode"),
@@ -655,12 +660,14 @@ class InitialConditions(ExtraBaseModel):
 
 
 class ThermalState(ExtraBaseModel):
-    ambient_temperature: FloatInt = Field(
+    ambient_temperature: FloatInt | None = Field(
+        None,
         alias="Ambient temperature [K]",
         examples=[298.15],
     )
 
-    heat_transfer_coefficient: FloatInt = Field(
+    heat_transfer_coefficient: FloatInt | None = Field(
+        None,
         alias="Heat transfer coefficient [W.m-2.K-1]",
         examples=[10.0],
     )
@@ -683,11 +690,13 @@ class Degradation(ExtraBaseModel):
 
 
 class State(ExtraBaseModel):
-    initial_conditions: InitialConditions = Field(
+    initial_conditions: InitialConditions | None = Field(
+        None,
         alias="Initial conditions",
     )
 
-    thermal_environment: ThermalState = Field(
+    thermal_environment: ThermalState | None = Field(
+        None,
         alias="Thermal environment",
     )
 
@@ -750,16 +759,6 @@ class BPX(ExtraBaseModel):
         return data
 
     @model_validator(mode="after")
-    def _check_state_present_if_not_partial(self) -> BPX:
-        """
-        Check that State is provided if not using a Partial parameterisation.
-        """
-        if self.state is None and self.header.model != "Partial":
-            err_msg = "'State' section must be provided unless using a 'Partial' parameterisation"
-            raise BPXSchemaError(err_msg)
-        return self
-
-    @model_validator(mode="after")
     def _check_state_against_blended_electrodes(self) -> BPX:
         """
         Check that if blended electrodes are used, values which require per-material
@@ -767,7 +766,7 @@ class BPX(ExtraBaseModel):
         """
 
         if self.state is None:
-            return self  # skip if no State provided (Partial parameterisation)
+            return self  # nothing to check if State is omitted
 
         param = self.parameterisation
 
@@ -776,16 +775,17 @@ class BPX(ExtraBaseModel):
             "positive_electrode": get_materials_in_electrode(param.positive_electrode),
         }
 
+        # Either section may be omitted (it is optional); validate_section_against_electrodes
+        # tolerates a None section.
         validate_section_against_electrodes(
             self.state.initial_conditions,
             "Initial conditions",
             electrode_materials,
         )
-        if self.state.degradation is not None:
-            validate_section_against_electrodes(
-                self.state.degradation,
-                "Degradation",
-                electrode_materials,
-            )
+        validate_section_against_electrodes(
+            self.state.degradation,
+            "Degradation",
+            electrode_materials,
+        )
 
         return self

--- a/bpx/schema_utils.py
+++ b/bpx/schema_utils.py
@@ -46,7 +46,13 @@ def _validate_value_against_keys(
 
     `expected_keys` is None for single-material electrodes (`value` must be scalar),
     or a set[str] for blended electrodes (`value` must be dict with `expected_keys`).
+
+    A `value` of None means the (optional) field was not provided, so there is
+    nothing to check against the electrode materials.
     """
+    if value is None:
+        return
+
     if expected_keys is None:
         # single-material: require scalar
         if isinstance(value, dict):
@@ -72,7 +78,7 @@ def _validate_value_against_keys(
 
 
 def validate_section_against_electrodes(
-    section_model: ExtraBaseModel,
+    section_model: ExtraBaseModel | None,
     section_label: str,
     electrode_materials: dict[str, set[str] | None],
 ) -> None:
@@ -82,6 +88,9 @@ def validate_section_against_electrodes(
     Assumes that fields which need to be checked are tagged with 'material_check' in their
     json_schema_extra metadata, with value 'negative_electrode' or 'positive_electrode'.
 
+    A `section_model` of None means the (optional) section was not provided, so there
+    is nothing to validate.
+
     E.g. for a single field:
 
     lam_positive: FloatInt | dict[str, FloatInt] = Field(
@@ -89,6 +98,9 @@ def validate_section_against_electrodes(
         json_schema_extra={"material_check": "positive_electrode"},
     )
     """
+    if section_model is None:
+        return
+
     for alias, value, tag in _find_tagged_fields(section_model):
         _validate_value_against_keys(
             value,

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -247,8 +247,12 @@ class TestParsers(unittest.TestCase):
         # moved fields are preserved
         assert bpx.state.thermal_environment.ambient_temperature == 299
         assert bpx.state.initial_conditions.initial_temperature == 299
-        # heat transfer coefficient is the placeholder (0), not carried from v0.x
-        assert bpx.state.thermal_environment.heat_transfer_coefficient == 0
+        # electrolyte concentration is carried across from the v0.x Electrolyte section
+        assert bpx.state.initial_conditions.initial_electrolyte_concentration == 1000
+        # optional fields with no v0.x equivalent are omitted (left to the simulator)
+        assert bpx.state.thermal_environment.heat_transfer_coefficient is None
+        assert bpx.state.initial_conditions.initial_hysteresis_state_positive is None
+        assert bpx.state.initial_conditions.initial_hysteresis_state_negative is None
 
     def test_v0_str_is_converted_with_warning(self) -> None:
         with _recorded_warnings() as records:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -759,13 +759,55 @@ class TestSchema(unittest.TestCase):
         ):
             adapter.validate_python(test)
 
-    def test_no_state_present_not_partial_error(self) -> None:
+    def test_no_state_present_allowed(self) -> None:
+        # State variables are optional (gh-126); a non-Partial file may omit State
+        # entirely and leave the simulator to default everything.
         test = copy.deepcopy(self.base_spm)
         del test["State"]
-        with pytest.raises(
-            ValidationError,
-            match=re.escape("'State' section must be provided unless using a 'Partial' parameterisation"),
-        ):
+        bpx = adapter.validate_python(test)
+        assert bpx.state is None
+
+    def test_optional_state_subsections(self) -> None:
+        # The Initial conditions and Thermal environment subsections are optional.
+        test = copy.deepcopy(self.base_spm)
+        test["State"] = {}
+        bpx = adapter.validate_python(test)
+        assert bpx.state.initial_conditions is None
+        assert bpx.state.thermal_environment is None
+
+    def test_optional_electrolyte_concentration(self) -> None:
+        # Initial electrolyte concentration is optional, e.g. for SPM (gh-127).
+        test = copy.deepcopy(self.base_spm)
+        del test["State"]["Initial conditions"]["Initial electrolyte concentration [mol.m-3]"]
+        bpx = adapter.validate_python(test)
+        assert bpx.state.initial_conditions.initial_electrolyte_concentration is None
+
+    def test_optional_hysteresis_state_blended(self) -> None:
+        # Hysteresis state is optional even for a blended electrode (gh-126): an
+        # omitted value must not trip the per-material dict check. base_spm has a
+        # blended positive electrode.
+        test = copy.deepcopy(self.base_spm)
+        del test["State"]["Initial conditions"]["Initial hysteresis state: Positive electrode"]
+        del test["State"]["Initial conditions"]["Initial hysteresis state: Negative electrode"]
+        bpx = adapter.validate_python(test)
+        assert bpx.state.initial_conditions.initial_hysteresis_state_positive is None
+        assert bpx.state.initial_conditions.initial_hysteresis_state_negative is None
+
+    def test_optional_thermal_environment_fields(self) -> None:
+        # Ambient temperature and heat transfer coefficient are optional (gh-126).
+        test = copy.deepcopy(self.base_spm)
+        del test["State"]["Thermal environment"]["Heat transfer coefficient [W.m-2.K-1]"]
+        del test["State"]["Thermal environment"]["Ambient temperature [K]"]
+        bpx = adapter.validate_python(test)
+        assert bpx.state.thermal_environment.heat_transfer_coefficient is None
+        assert bpx.state.thermal_environment.ambient_temperature is None
+
+    def test_blended_hysteresis_keys_still_checked_when_present(self) -> None:
+        # Optionality must not weaken the per-material check when a value IS given:
+        # a scalar for a blended electrode is still rejected.
+        test = copy.deepcopy(self.base_spm)
+        test["State"]["Initial conditions"]["Initial hysteresis state: Positive electrode"] = 1.0
+        with pytest.raises(ValidationError, match=re.escape("must be a dict")):
             adapter.validate_python(test)
 
 


### PR DESCRIPTION
## Summary

Makes all `State` variables optional, addressing **#126** (the schema treats State variables as required even though the written standard uses permissive language, and they affect simulation rather than the cell description) and **#127** (initial electrolyte concentration is required even for SPM, which has no `Electrolyte` section).

Every `State` field now defaults to `None`, leaving simulators to apply their own defaults for anything not provided.

> [!NOTE]
> This PR targets `feat/v0-backward-compat` (#128), not `main` — it builds on the legacy-conversion work there.

## Changes

- **Schema** (`bpx/schema.py`): all fields in `InitialConditions` and `ThermalState`, plus the `initial_conditions` / `thermal_environment` containers, are now `| None` defaulting to `None`. A non-`Partial` file may now omit the `State` section entirely; the `_check_state_present_if_not_partial` validator is removed.
- **Material check** (`bpx/schema_utils.py`): `validate_section_against_electrodes` and `_validate_value_against_keys` tolerate `None`, so an omitted field (e.g. hysteresis state) no longer trips the per-material dict check on a blended electrode. The check still fires when a value *is* supplied.
- **Legacy converter** (`bpx/_migrations.py`): no longer synthesises placeholder hysteresis / heat-transfer / electrolyte values; it carries across only what the v0.x file actually provides (keeping the SOC default and temperature-resolution chain). This removes the meaningless `hysteresis = 0` that #126 objects to.
- **Tests**: replaced the obsolete "State required" test with coverage for omitted `State`, omitted subsections, optional electrolyte concentration (#127), optional hysteresis on a blended electrode (#126), optional thermal fields, and a regression guard that the per-material check still rejects a scalar for a blended electrode.

## ⚠️ For discussion: `None` propagation to consumers

Previously, every `State` field was guaranteed present on a validated non-`Partial` `BPX` object, so consumers could read e.g. `bpx.state.initial_conditions.initial_electrolyte_concentration` unconditionally. **After this change, any of these can be `None`** — including `bpx.state` itself, the `initial_conditions` / `thermal_environment` subsections, and every scalar field.

Consumers (e.g. PyBaMM's BPX loader) will need to handle `None` and supply their own defaults. Worth deciding as a group:

1. **Is fully optional the right scope for #126**, or should some fields stay required (e.g. `Initial state-of-charge` as the one fundamental initial condition)? This PR takes the literal "all optional" reading.
2. **Should `bpx` itself expose the defaulting** (e.g. a documented set of fallback values, or accessor helpers that fill defaults) so each downstream simulator doesn't reinvent it and risk diverging?
3. The legacy converter now *omits* fields rather than defaulting them — so a converted v0.x SPM file yields `initial_electrolyte_concentration = None`. Is "omit and let the simulator default" preferred over "convert to an explicit value"?

Happy to adjust scope based on the answer to (1).

Closes #126
Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)